### PR TITLE
Change on creative level to track fulfillment

### DIFF
--- a/schema/creative.json
+++ b/schema/creative.json
@@ -50,6 +50,16 @@
 		},
 		"priority": {
 			"$ref": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/priority.json"
+		},
+		"valueBooked": {
+			"type": "number",
+			"multipleOf": 1.0,
+			"minimum": 0
+		},
+		"valueFulfilled": {
+			"type": "number",
+			"multipleOf": 1.0,
+			"minimum": 0			
 		}
 	},
 	"required": [


### PR DESCRIPTION
A campaign might have different creatives with different promised impressions, so it would make sense for booked and fulfilled values to reside at the creative level. Addresses Issue #2.