### PR TITLE
Brand safety rating integrated into targeting process

### DIFF
--- a/schema/targeting.json
+++ b/schema/targeting.json
@@ -37,9 +37,6 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
-				"keywords": {
-					"$ref": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/keywords.json"
-				},
 				"articleIds": {
 					"type": "array",
 					"items": {
@@ -51,16 +48,15 @@
 					"items": {
 						"type": "string"
 					}
-				},
-				"brandSafetyLevel": {
-					"type": "number",
-					"minimum": 1,
-					"maximum": 10
 				}
 			}
 		},
 		"priority": {
 			"$ref": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/priority.json"
 		}
-	}
+	},
+	"required": [
+		"products",
+		"exclusions"
+	]
 }

--- a/schema/targeting.json
+++ b/schema/targeting.json
@@ -12,7 +12,10 @@
 			}
 		},
 		"keywords": {
-			"$ref": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/keywords.json"
+			"type": "array",
+			"items": {
+				"$ref": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/keyword.json"
+			}
 		},
 		"commercialNode": {
 			"oneOf": [

--- a/schema/targeting.json
+++ b/schema/targeting.json
@@ -51,6 +51,11 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"brandSafetyLevel": {
+					"type": "number",
+					"minimum": 1,
+					"maximum": 10
 				}
 			}
 		},

--- a/schema/traits/keyword.json
+++ b/schema/traits/keyword.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"id": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/keywords.json",
+	"id": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/keyword.json",
 	"title": "Keywords trait",
 	"description": "An optional list of strings to target for an ad.",
 	"type": "object",

--- a/schema/traits/keywords.json
+++ b/schema/traits/keywords.json
@@ -3,8 +3,20 @@
 	"id": "https://raw.githubusercontent.com/washingtonpost/ad-schema/master/schema/traits/keywords.json",
 	"title": "Keywords trait",
 	"description": "An optional list of strings to target for an ad.",
-	"type": "array",
-	"items": {
-		"type": "string"
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"_id": {
+			"$ref": "https://raw.githubusercontent.com/washingtonpost/ans-schema/master/src/main/resources/schema/ans/0.6.2/traits/trait_id.json"
+		},
+		"name": {
+			"type": "string"
+		},
+		"brandSafetyLevel": {
+			"type": "number",
+			"minimum": 1,
+			"maximum": 10,
+			"description": "The brand safety level of articles with this keyword must match or exceed the targeted brand safety level with 1 = least safe, 10 = safest. 10 assumed if this is not listed."
+		}
 	}
 }


### PR DESCRIPTION
Aiming to resolve #6 this PR removes the need for keywords at the exclusion level, instead allowing campaign targeting to set keywords with brand safety levels attached. Keyword exclusion can then be managed at that level. 